### PR TITLE
UA_Server_getVariableNode_valueCallback() needs UA_EXPORT

### DIFF
--- a/include/open62541/server.h
+++ b/include/open62541/server.h
@@ -1046,8 +1046,9 @@ UA_Server_setVariableNode_valueCallback(UA_Server *server,
                                         const UA_NodeId nodeId,
                                         const UA_ValueCallback callback);
 
-UA_StatusCode
-UA_Server_getVariableNode_valueCallback(UA_Server *server, const UA_NodeId nodeId,
+UA_StatusCode UA_EXPORT
+UA_Server_getVariableNode_valueCallback(UA_Server *server,
+                                        const UA_NodeId nodeId,
                                         UA_ValueCallback *outValue);
 
 UA_StatusCode UA_EXPORT UA_THREADSAFE


### PR DESCRIPTION
The `UA_EXPORT` tag is required to export the symbol in shared objects. This was not noticed before because the symbol need not be exported when the library is fetched via FetchContent() and compiled and linked in-tree. Rather, it appears when open62541 is built separately and linked dynamically with the SDK (which is the case in the Yocto layer).